### PR TITLE
fix zigbee_ota.py for python 3.8

### DIFF
--- a/make/zigbee_ota.py
+++ b/make/zigbee_ota.py
@@ -11,7 +11,7 @@ OTA_MAGIC = b'\x5d\x02'
 def main(args):
     assert args.input_file != args.output
 
-    with (open(args.input_file, 'rb') as bin_file):
+    with (open(args.input_file, 'rb')) as bin_file:
         bin_file.seek(0, 0)
         firmware = bytearray(bin_file.read(-1))
         if firmware[6:8] != OTA_MAGIC:


### PR DESCRIPTION
fixes:
```
Create OTA image
 
  File "./make/zigbee_ota.py", line 14
    with (open(args.input_file, 'rb') as bin_file):
                                      ^
SyntaxError: invalid syntax
make: *** [makefile:156: bin/z03mmc.zigbee] Error 1
```
on python 3.8.10 