### PR TITLE
Платы с USE_SENSOR_LX: добавить zlx2lx.o в src.mk и реализовать mul32x32_64

### DIFF
--- a/make_z/src.mk
+++ b/make_z/src.mk
@@ -35,6 +35,7 @@ $(OUT_PATH)$(SRC_DIR)/sensor_th.o \
 $(OUT_PATH)$(SRC_DIR)/sensor_rh.o \
 $(OUT_PATH)$(SRC_DIR)/sensor_pir.o \
 $(OUT_PATH)$(SRC_DIR)/sensor_lx.o \
+$(OUT_PATH)$(SRC_DIR)/zlx2lx.o \
 $(OUT_PATH)$(SRC_DIR)/sensor_xbr818.o \
 $(OUT_PATH)$(SRC_DIR)/sensors_zg223z.o \
 $(OUT_PATH)$(SRC_DIR)/zb_appCb.o \
@@ -43,6 +44,7 @@ $(OUT_PATH)$(SRC_DIR)/reporting.o \
 $(OUT_PATH)$(SRC_DIR)/custom_zcl/zcl_relative_humidity.o \
 $(OUT_PATH)$(SRC_DIR)/custom_zcl/zcl_thermostat_ui_cfg.o \
 $(OUT_PATH)$(SRC_DIR)/custom_zcl/zcl_illuminance_level_sensing.o \
+$(OUT_PATH)$(SRC_DIR)/custom_zcl/zcl_dehumidification_control.o \
 $(OUT_PATH)$(SRC_DIR)/main.o \
 $(OUT_PATH)$(SRC_DIR)/sws_printf.o \
 $(OUT_PATH)$(SRC_DIR)/trigger.o

--- a/src/sensors_zg223z.c
+++ b/src/sensors_zg223z.c
@@ -16,7 +16,7 @@
 #endif
 
 
-extern u64 mul32x32_64(u32 a, u32 b); // hard function (in div_mod.S)
+extern u64 mul32x32_64(u32 a, u32 b); // in zlx2lx.c
 
 //#define USE_ILLUMI_AVERAGE_SHL 	2 // 2
 

--- a/src/zlx2lx.c
+++ b/src/zlx2lx.c
@@ -8,7 +8,31 @@
 #include "tl_common.h"
 #if USE_SENSOR_LX
 
-extern u64 mul32x32_64(u32 a, u32 b); // hard function (in div_mod.S)
+/* 32x32 -> 64 bit unsigned multiply.
+ * The image is linked with -nostdlib, so (u64)a*b would pull __muldi3
+ * from libgcc: keep it on 32-bit operations. */
+u64 mul32x32_64(u32 a, u32 b) {
+	union {
+		u64 value;
+		struct {
+			u32 lo;
+			u32 hi;
+		} word;
+	} result;
+	u32 al = a & 0xffff;
+	u32 ah = a >> 16;
+	u32 bl = b & 0xffff;
+	u32 bh = b >> 16;
+	u32 ll = al * bl;
+	u32 lh = al * bh;
+	u32 hl = ah * bl;
+	// three 16-bit halves fit into 32 bits, the carry goes to the high word
+	u32 mid = (ll >> 16) + (lh & 0xffff) + (hl & 0xffff);
+
+	result.word.lo = (ll & 0xffff) | (mid << 16);
+	result.word.hi = (ah * bh) + (lh >> 16) + (hl >> 16) + (mid >> 16);
+	return result.value;
+}
 
 // Коэффициенты полинома для 2^x, x∈[0,1) (масштаб 2^F)
 #define A1      726817U


### PR DESCRIPTION
Исправляет #297: на master (`a33813c`) ни одна плата с датчиком освещённости не линкуется.

**1. `zlx2lx.o` не попал в `make_z/src.mk`.** В `c48af2a` `pow10_fixed()` и
`calk_10000_log10()` переехали из `src/sensor_lx.c` в новый `src/zlx2lx.c`, а список
объектов остался прежним — отсюда `undefined reference to pow10_fixed` /
`calk_10000_log10`.

**2. Нет символа `mul32x32_64`.** Комментарий в `zlx2lx.c` и `sensors_zg223z.c` говорит
«hard function (in div_mod.S)», но в `SDK_z/platform/tc32/div_mod.S` её нет (только
`__divsi3`, `__modsi3`, `__udivsi3`, `__umodsi3`, `div`), нет её и в `libdrivers_8258.a`.
Добавил реализацию на 32-битных операциях прямо в `zlx2lx.c` (он собирается при
`USE_SENSOR_LX`, то есть на всех трёх платах, включая ZG-223Z). Через `(u64)a * b` не
получается: образ линкуется с `-nostdlib`, и вылезает `__muldi3` из libgcc. Если у вас
есть ассемблерный вариант — эта функция ему не мешает, замените.

Результат проверен на хосте перебором: совпадает с `(uint64_t)a * b` на границах
(0, 1, 0xFFFF, 0x10000, 0xFFFFFFFF, коэффициенты полинома) и на 3 млн случайных пар.

**3. `zcl_dehumidification_control.o` тоже не в `src.mk`.** Вылезло после первых двух
правок: `BOARD_ZG223Z` падал на `undefined reference to
zcl_dehumidification_control_register`. Файл целиком под `#ifdef
ZCL_DIHUMIDIFICATION_CONTROL`, на остальные платы объект добавляет ноль байт.

## Проверка

Сборка тулчейном из репозитория (Debian, linux/amd64), чистое дерево:

| Плата | master | с патчем |
|---|---|---|
| `BOARD_ZG204ZL` | undefined `pow10_fixed`, `calk_10000_log10` | ok, 129112 байт |
| `BOARD_ZG204ZV` | то же | ok, 132052 байт |
| `BOARD_ZG223Z` | то же + `zcl_dehumidification_control_register` | ok, 131604 байт |