### PR TITLE
zcl_illuminanceConfig_save(): писать конфигурацию света в NV_ITEM_APP_ILLUMI_CFG

### DIFF
--- a/src/app_EpCfg.c
+++ b/src/app_EpCfg.c
@@ -733,7 +733,7 @@ void zcl_illuminanceConfig_save(int init) {
 			}
 #endif
 			if(memcmp(&g_zcl_illuminanceAttrs.cfg, &icfg, sizeof(icfg))) {
-				nv_flashWriteNew(1, NV_MODULE_APP, NV_ITEM_APP_PIR_CFG,
+				nv_flashWriteNew(1, NV_MODULE_APP, NV_ITEM_APP_ILLUMI_CFG,
 						sizeof(g_zcl_illuminanceAttrs.cfg), (u8*)&g_zcl_illuminanceAttrs.cfg);
 		    	sws_puts("NV: illumiCfg saved\n");
 			}


### PR DESCRIPTION
Исправляет #298. В `zcl_illuminanceConfig_save()` (`src/app_EpCfg.c`) чтение идёт из
`NV_ITEM_APP_ILLUMI_CFG`, а запись — в `NV_ITEM_APP_PIR_CFG`.

Следствия два:

1. Калибровка света не переживает перезагрузку: `init_nv_app()` →
   `zcl_illuminanceConfig_save(1)` читает пустой `NV_ITEM_APP_ILLUMI_CFG` и подставляет
   `ADC_LX_ZERO_DEF` / `ADC_LX_COEF_DEF` / `READ_SENSOR_TIMER_SEC`, сколько бы раз
   атрибуты `0x5000`–`0x5002` ни писали.
2. Та же запись затирает `NV_ITEM_APP_PIR_CFG`, где `zcl_occupanceConfig_save()` хранит
   occupancy delay: правка калибровки света молча сбрасывает задержку присутствия.

Правка на одну строку — имя item'а при записи. Затрагивает `BOARD_ZG204ZL`,
`BOARD_ZG204ZV`, `BOARD_ZG223Z`.

Собрано для `BOARD_ZG204ZL` поверх #299 (без него платы с `USE_SENSOR_LX` не линкуются
вообще): линкуется, размер образа не меняется.