### PR TITLE
Add HOBEIAN ZG-204ZV boards 54/55 and fix XBR818 occupancy at fading_time=0

### DIFF
--- a/WinMakeZ.cmd
+++ b/WinMakeZ.cmd
@@ -83,6 +83,12 @@ make -s -j clean
 make -s -j VERSION_BIN=%SWVER% PROJECT_NAME=ZG204ZV POJECT_DEF="-DBOARD=BOARD_ZG204ZV" ZNAME="Sonoff:ZG-204ZV-z"
 @if not exist "bin\ZG204ZV%SWVER%.bin" goto :error
 make -s -j clean
+make -s -j VERSION_BIN=%SWVER% PROJECT_NAME=ZG204ZVN POJECT_DEF="-DBOARD=BOARD_ZG204ZVN" ZNAME="Sonoff:ZG-204ZVN-z"
+@if not exist "bin\ZG204ZVN%SWVER%.bin" goto :error
+make -s -j clean
+make -s -j VERSION_BIN=%SWVER% PROJECT_NAME=ZG204ZVH POJECT_DEF="-DBOARD=BOARD_ZG204ZVH" ZNAME="Sonoff:ZG-204ZV-z"
+@if not exist "bin\ZG204ZVH%SWVER%.bin" goto :error
+make -s -j clean
 make -s -j VERSION_BIN=%SWVER% PROJECT_NAME=TS0201W POJECT_DEF="-DBOARD=BOARD_TS0201WING" ZNAME="Wing:TS0201-z"
 @if not exist "bin\TS0201W%SWVER%.bin" goto :error
 make -s -j clean

--- a/src/app_cfg.h
+++ b/src/app_cfg.h
@@ -143,7 +143,7 @@
 #include "board_rsh_hs03.h"
 #elif BOARD == BOARD_ZG204ZL
 #include "board_zg204zl.h"
-#elif BOARD == BOARD_ZG204ZV
+#elif (BOARD == BOARD_ZG204ZV || BOARD == BOARD_ZG204ZVH || BOARD == BOARD_ZG204ZVN)
 #include "board_zg204zv.h"
 #elif BOARD == BOARD_TS0201WING
 #include "board_ts0201_wing.h"

--- a/src/app_main.c
+++ b/src/app_main.c
@@ -266,7 +266,7 @@ void show_th(void) {
 
 
 void read_sensor_and_show(void) {
-#if (USE_SENSOR_LX == 1) || (USE_SENSOR_RND)
+#if (USE_SENSOR_LX == 1) || ((USE_SENSOR_LX == 2) && !USE_SENSOR_TH) || (USE_SENSOR_RND)
 #if (USE_SENSOR_RND)
 	read_sensors();
 #else
@@ -334,7 +334,7 @@ s32 sensors_task(void *arg) {
 		if(tt - g_sensorAppCtx.readSensorTime >= g_sensorAppCtx.measureInterval) {
 			g_sensorAppCtx.readSensorTime = tt;
 			read_sensor_and_show();
-#if USE_SENSOR_LX == 1
+#if (USE_SENSOR_LX == 1) || ((USE_SENSOR_LX == 2) && !USE_SENSOR_TH)
 			g_sensorAppCtx.reportFlg = FLG_CHECK_REPORT; // check report table
 #endif
 		}

--- a/src/board_zg204zv.h
+++ b/src/board_zg204zv.h
@@ -9,11 +9,15 @@
 
 #include "version_cfg.h"
 
-#if (BOARD == BOARD_ZG204ZV)
+#if (BOARD == BOARD_ZG204ZV || BOARD == BOARD_ZG204ZVH || BOARD == BOARD_ZG204ZVN)
 
 //#define SWS_PRINTF_MODE	1
 
+#if (BOARD == BOARD_ZG204ZV || BOARD == BOARD_ZG204ZVH)
 #define DEV_SERVICES (SERVICE_ZIGBEE | SERVICE_LED | SERVICE_OTA | SERVICE_THS | SERVICE_PIR | SERVICE_ILLUMI)
+#else
+#define DEV_SERVICES (SERVICE_ZIGBEE | SERVICE_LED | SERVICE_OTA | SERVICE_PIR | SERVICE_ILLUMI)
+#endif
 
 /* https://pvvx.github.io/ZG-204ZL-3.0/
  TLSR8253F512ET32 512K Flash
@@ -31,11 +35,15 @@
  GPIO_PA1 - XBR818 SDA
 */
 
-#define BLE_MODEL_STR		"ZG-204ZV"
 #define BLE_MAN_STR			"Sonoff"
-
 #define ZCL_BASIC_MFG_NAME     {6,'S','o','n','o','f','f'} // Sonoff
+#if (BOARD == BOARD_ZG204ZVN)
+#define BLE_MODEL_STR		"ZG-204ZVN"
+#define ZCL_BASIC_MODEL_ID	   {11,'Z','G','-','2','0','4','Z','V','N','-','z'} // ZG-204ZVN-z
+#else
+#define BLE_MODEL_STR		"ZG-204ZV"
 #define ZCL_BASIC_MODEL_ID	   {10,'Z','G','-','2','0','4','Z','V','-','z'} // ZG-204ZV-z
+#endif
 
 // Battery & RF Power
 #define USE_BATTERY 	BATTERY_2AAA
@@ -47,7 +55,11 @@
 
 #define USE_SENSOR_CHT8305		0
 #define USE_SENSOR_CHT8215		0
+#if (BOARD == BOARD_ZG204ZV || BOARD == BOARD_ZG204ZVH)
 #define USE_SENSOR_AHT20_30		1
+#else
+#define USE_SENSOR_AHT20_30		0
+#endif
 #define USE_SENSOR_SHT4X		0
 #define USE_SENSOR_SHTC3		0
 #define USE_SENSOR_SHT30		0
@@ -89,13 +101,14 @@
 #define DEF_OCCUPANCY_DELAY		35	// sec (PIR sensor)
 
 #define PIR_ON				1
+#define USE_SENSOR_XBR818	1
+
+#if (BOARD == BOARD_ZG204ZV)
 #define GPIO_PIR			GPIO_PD7
 #define PD7_INPUT_ENABLE	1
 #define PD7_DATA_OUT		0
 #define PD7_OUTPUT_ENABLE	0
 #define PD7_FUNC			AS_GPIO
-
-#define USE_SENSOR_XBR818	1
 
 #define XBR818_SCL			GPIO_PA0
 #define PA0_INPUT_ENABLE	1
@@ -112,6 +125,29 @@
 #define PULL_WAKEUP_SRC_PA1 PM_PIN_PULLUP_10K
 
 #define XBR818_OUT			GPIO_PD7
+#else
+#define GPIO_PIR			GPIO_PA1
+#define PA1_INPUT_ENABLE	1
+#define PA1_DATA_OUT		0
+#define PA1_OUTPUT_ENABLE	0
+#define PA1_FUNC			AS_GPIO
+
+#define XBR818_SCL			GPIO_PD7
+#define PD7_INPUT_ENABLE	1
+#define PD7_DATA_OUT		0
+#define PD7_OUTPUT_ENABLE	0
+#define PD7_FUNC			AS_GPIO
+#define PULL_WAKEUP_SRC_PD7 PM_PIN_PULLUP_10K
+
+#define XBR818_SDA			GPIO_PA0
+#define PA0_INPUT_ENABLE	1
+#define PA0_DATA_OUT		0
+#define PA0_OUTPUT_ENABLE	0
+#define PA0_FUNC			AS_GPIO
+#define PULL_WAKEUP_SRC_PA0 PM_PIN_PULLUP_10K
+
+#define XBR818_OUT			GPIO_PA1
+#endif
 
 // illuminance sensor
 #define USE_SENSOR_LX		2 // =1 - ADC = Ur, =2 - ADC = Us

--- a/src/reporting.c
+++ b/src/reporting.c
@@ -114,7 +114,6 @@ status_t app_chk_report(u16 uptime_sec) {
 							len = zcl_getAttrSize(pAttrEntry->type, pAttrEntry->data);
 							len = (len > 8) ? (8): (len);
 							if(memcmp(pEntry->prevData, pAttrEntry->data, len) != SUCCESS) {
-								memcpy(pEntry->prevData, pAttrEntry->data, len);
 								flg_report = true;
 							}
 						}
@@ -139,12 +138,6 @@ status_t app_chk_report(u16 uptime_sec) {
 				            dstEpInfo.dstAddrMode = APS_DSTADDR_EP_NOTPRESETNT;
 				            dstEpInfo.profileId = pEntry->profileID;
 
-				            if(!flg_chk_attr) {
-				            	len = zcl_getAttrSize(pAttrEntry->type, pAttrEntry->data);
-				            	len = (len>8) ? (8):(len);
-				            	memcpy(pEntry->prevData, pAttrEntry->data, len);
-				            }
-
 				            if(zcl_sendReportCmd(pEntry->endPoint,
 									&dstEpInfo,
 									TRUE, ZCL_FRAME_SERVER_CLIENT_DIR,
@@ -157,6 +150,10 @@ status_t app_chk_report(u16 uptime_sec) {
 				            	status = ZCL_STA_INSUFFICIENT_SPACE;
 
 				            	pEntry->maxIntCnt = 0; // repeat after
+							} else {
+								len = zcl_getAttrSize(pAttrEntry->type, pAttrEntry->data);
+								len = (len > 8) ? (8): (len);
+								memcpy(pEntry->prevData, pAttrEntry->data, len);
 							}
 				            sws_printf("checkReport: %04x:%04x %d,%d,%d:%d %02x\n",
 				            		pEntry->clusterID, pAttrEntry->id,

--- a/src/sensor_lx.c
+++ b/src/sensor_lx.c
@@ -113,7 +113,7 @@ int read_illumi_sensor(void) {
 	return 0;
 }
 
-#if USE_SENSOR_LX == 1 // =1 - ADC = Ur, =2 - ADC = Us
+#if (USE_SENSOR_LX == 1) || ((USE_SENSOR_LX == 2) && !USE_SENSOR_TH) // =1 - ADC = Ur, =2 - ADC = Us
 void init_sensor(void) {
 
 }

--- a/src/sensor_pir.c
+++ b/src/sensor_pir.c
@@ -48,7 +48,12 @@ static s32 occupancyTimerCb(void *arg) {
 void task_pir(void) {
 	zcl_onOffAttr_t *pOnOff = zcl_onoffAttrGet();
 	u8 pir_on = gpio_read(GPIO_PIR)? PIR_ON : !PIR_ON;
-	if(zcl_occupAttr.delay) {
+#if USE_SENSOR_XBR818
+	/* XBR818 handles the hold time in hardware; delay==0 is valid. */
+#else
+	if(zcl_occupAttr.delay)
+#endif
+	{
 		if(pir_on) {
 			// PIR On
 			if(!zcl_occupAttr.state) {

--- a/src/version_cfg.h
+++ b/src/version_cfg.h
@@ -99,6 +99,8 @@
 #define BOARD_ZG204ZV				51 // HOBEIAN-ZG-204ZV T&H + LUX + Radar Sensor XBR818
 #define BOARD_TS0201WING			52 // TS0201_TZ3000_dnpd6ayp, Tuya Zigbee "Temp & Humidity Sensor", Wing TS0201 2xAAA
 #define BOARD_ZG223Z				53 // HOBEIAN ZG223Z, Zigbee "Raindrop Detection Senser" + Lx, CR123A
+#define BOARD_ZG204ZVN				54 // HOBEIAN-ZG-204ZV without T&H, LUX + Radar Sensor XBR818
+#define BOARD_ZG204ZVH				55 // HOBEIAN-ZG-204ZV T&H + LUX + Radar Sensor XBR818 (HOBEIAN GPIO)
 
 /* Board define */
 #ifndef BOARD


### PR DESCRIPTION
## Summary

Add support for the HOBEIAN ZG-204ZV hardware variants and fix XBR818 occupancy handling when the configured hold time is `0`.

This adds two new board definitions:
* `BOARD_ZG204ZVN` (54) — HOBEIAN ZG-204ZV without WHT20
* `BOARD_ZG204ZVH` (55) — HOBEIAN ZG-204ZV with WHT20

The existing `BOARD_ZG204ZV` (51) GPIO mapping is preserved unchanged.

## Hardware

The HOBEIAN variants use the same PCB and XBR818 radar as the existing ZG-204ZV, but the XBR818 GPIO routing differs.

### Existing pvvx ZG-204ZV (board 51)

* PIR / XBR818 OUT: `PD7`
* XBR818 SCL: `PA0`
* XBR818 SDA: `PA1`
* WHT20 SDA: `PC3`
* WHT20 SCL: `PC4`

### HOBEIAN ZG-204ZV (boards 54/55)

* PIR / XBR818 OUT: `PA1`
* XBR818 SCL: `PD7`
* XBR818 SDA: `PA0`
* WHT20 SDA: `PC3`
* WHT20 SCL: `PC4`

Board 54 has no WHT20 sensor. Board 55 has the WHT20 populated on the same PCB.

A top-side PCB photo of the HOBEIAN board (ZVN, WHT20 unpopulated) is included as hardware reference. ZVH uses the same PCB with WHT20 fitted.

OTA `IMAGE_TYPE` is `(CHIP_TYPE << 8) | BOARD`, so the images remain distinct:
* Board 51: `0x0233`
* Board 54: `0x0236`
* Board 55: `0x0237`

## Model IDs

* Board 51: `ZG-204ZV-z`
* Board 55: `ZG-204ZV-z`
* Board 54: `ZG-204ZVN-z`

Board 55 intentionally uses the same Model ID as the existing ZG-204ZV because the exposed clusters and sensors are the same. The OTA image type still differs, so firmware images remain board-specific.

## Why two board definitions

Although boards 54 and 55 use the same PCB, they are intentionally implemented as separate board definitions because the available hardware differs.

`BOARD_ZG204ZVN` (54) has no WHT20 fitted and therefore must not enable the T/H service or expose temperature/humidity clusters.

`BOARD_ZG204ZVH` (55) has the WHT20 fitted and does enable the T/H service.

Using a single board definition would enable T/H functionality on the hardware variant where the sensor is not physically present. This would result in non-functional temperature/humidity entities in Zigbee applications.

Separate board definitions therefore ensure that the firmware only enables services and exposes clusters for hardware that is actually present on each variant.

## Firmware changes

### HOBEIAN board variants

Add board IDs, board selection, GPIO definitions, model IDs and service/sensor configuration for boards 54 and 55.

The ZVN variant does not include the T/H service or WHT20 initialization.

### Illuminance without T/H

Allow the existing LX sensor path to operate for `USE_SENSOR_LX == 2` when no T/H sensor is present.

This is required for the ZG-204ZVN variant.

### Reporting retry fix

Fix a reporting issue where `prevData` could be updated before `zcl_sendReportCmd()` successfully accepted the report.

When transmission failed, the stored previous value could therefore prevent a later retry from being detected as a change.

`prevData` is now updated only after a successful report submission.

This change is generic and independent of the HOBEIAN board variants.

### XBR818 occupancy fix

For XBR818 devices, the radar itself controls the occupancy hold time.

`fading_time = 0` is a valid XBR818 configuration and programs a short hardware hold of approximately 2 seconds.

Previously, `task_pir()` used `delay == 0` to skip the entire occupancy state machine. This meant that the falling edge of the XBR818 output was ignored and occupancy could remain permanently active.

The XBR818 path now processes the GPIO state regardless of `delay`, while the existing `delay` behaviour for non-XBR818 PIR implementations is unchanged.

This affects boards 51, 54 and 55 (`USE_SENSOR_XBR818`).

## Testing

### HOBEIAN ZG-204ZV with WHT20 (board 55)

* XBR818 occupancy detection
* Illuminance
* Temperature
* Humidity
* `motion_detection_sensitivity`
* `fading_time = 0` → occupancy clears after approximately 2 seconds
* `fading_time = 1` → occupancy clears correctly
* `fading_time = 255` → occupancy clears after the configured hold time

### HOBEIAN ZG-204ZV without WHT20 (board 54)

* XBR818 occupancy detection
* Illuminance
* `fading_time = 0` → occupancy clears correctly after approximately 2 seconds
* `fading_time = 1` → occupancy clears correctly

Board 51 was rebuilt successfully and its existing GPIO mapping was verified unchanged. The `fading_time = 0` behaviour was not physically retested on the original pvvx ZG-204ZV hardware because such a device was not available.

### Builds

Successful builds were performed for:
* `BOARD_ZG204ZV` (51)
* `BOARD_ZG204ZVN` (54)
* `BOARD_ZG204ZVH` (55)

No new compiler warnings were introduced by these changes.

The existing Telink linker warnings for `ss_apsmeSwitchKeyReq`, `ss_apsmeTransportKeyReq` and `tl_zbNwkBeaconPayloadUpdate` remain unchanged.

## Files changed

* `src/version_cfg.h`
* `src/app_cfg.h`
* `src/board_zg204zv.h`
* `src/app_main.c`
* `src/sensor_lx.c`
* `src/reporting.c`
* `src/sensor_pir.c`
* `WinMakeZ.cmd`

Generated binaries and local development-container changes are not part of this PR.